### PR TITLE
feat: register new copiers

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -74,6 +74,18 @@ func Anything(x interface{}) (interface{}, error) {
 
 func _anything(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) {
 	v := ValueOf(x)
+
+	if cloner := v.MethodByName("Clone"); cloner.IsValid() {
+		switch cloner.Type().NumIn() {
+		case 0:
+			return cloner.Call([]Value{})[0].Interface(), nil
+		case 1:
+			return cloner.Call([]Value{ValueOf(ptrs)})[0].Interface(), nil
+		default:
+			return nil, fmt.Errorf("clone method for %v has too many arguments", x)
+		}
+	}
+
 	if !v.IsValid() {
 		return x, nil
 	}

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -36,6 +36,10 @@ func init() {
 	}
 }
 
+func Register(kind Kind, copier copier) {
+	copiers[kind] = copier
+}
+
 // MustAnything does a deep copy and panics on any errors.
 func MustAnything(x interface{}) interface{} {
 	dc, err := Anything(x)
@@ -132,7 +136,7 @@ func _pointer(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) 
 
 	if v.IsNil() {
 		t := TypeOf(x)
-		return Zero(t).Interface(),nil
+		return Zero(t).Interface(), nil
 	}
 
 	addr := v.Pointer()
@@ -142,7 +146,7 @@ func _pointer(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) 
 	t := TypeOf(x)
 	dc := New(t.Elem())
 	ptrs[addr] = dc.Interface()
-	
+
 	item, err := _anything(v.Elem().Interface(), ptrs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy the value under the pointer %v: %v", v, err)
@@ -151,7 +155,7 @@ func _pointer(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) 
 	if iv.IsValid() {
 		dc.Elem().Set(ValueOf(item))
 	}
-	
+
 	return dc.Interface(), nil
 }
 

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -74,6 +74,9 @@ func Anything(x interface{}) (interface{}, error) {
 
 func _anything(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) {
 	v := ValueOf(x)
+	if !v.IsValid() {
+		return x, nil
+	}
 
 	if cloner := v.MethodByName("Clone"); cloner.IsValid() {
 		switch cloner.Type().NumIn() {
@@ -86,9 +89,6 @@ func _anything(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error)
 		}
 	}
 
-	if !v.IsValid() {
-		return x, nil
-	}
 	if c, ok := copiers[v.Kind()]; ok {
 		return c(x, ptrs)
 	}
@@ -187,7 +187,9 @@ func _struct(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to copy the field %v in the struct %#v: %v", t.Field(i).Name, x, err)
 		}
-		dc.Elem().Field(i).Set(ValueOf(item))
+    if val := ValueOf(item); val.IsValid() {
+      dc.Elem().Field(i).Set(val)
+    }
 	}
 	return dc.Elem().Interface(), nil
 }


### PR DESCRIPTION
We needed to be able to copy structs with lists of functions. For our use case shallow copy of functions is acceptable.

This PR, along with 
```go
	deepcopy.Register(reflect.Func, func(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) {
		return x, nil
	})
```
handles the scenario well.