### PR TITLE
Allow registering immutable struct types that will not be deep-copied

### DIFF
--- a/deepcopy.go
+++ b/deepcopy.go
@@ -51,7 +51,10 @@ func MustAnything(x interface{}) interface{} {
 
 // RegisterImmutableType registers a type as immutable. This means that when a deep copy is made,
 // if the type of the value being copied is the same as the type passed in, the value will not be
-// copied. Instead, the original value will be used. This is useful for types that are immutable
+// copied. Instead, the original value will be used. This is useful for types that are immutable.
+//
+// It is intended to be called at init time.
+
 func RegisterImmutableType(t Type) {
 	immutableTypes[t] = struct{}{}
 }

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -47,8 +47,8 @@ type Foo struct {
 
 func ExampleMap() {
 	x := map[string]*Foo{
-		"foo": &Foo{Bar: 1},
-		"bar": &Foo{Bar: 2},
+		"foo": {Foo: &Foo{Bar: 1}, Bar: 1},
+		"bar": {Foo: &Foo{Bar: 2}, Bar: 2},
 	}
 	y := MustAnything(x).(map[string]*Foo)
 	for _, k := range []string{"foo", "bar"} { // to ensure consistent order

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	. "reflect"
 	"testing"
+	"time"
 )
 
 func ExampleAnything() {
@@ -161,8 +162,8 @@ func TestTwoNils(t *testing.T) {
 		B int
 	}
 	type FooBar struct {
-		Foo *Foo
-		Bar *Bar
+		Foo  *Foo
+		Bar  *Bar
 		Foo2 *Foo
 		Bar2 *Bar
 	}
@@ -178,4 +179,30 @@ func TestTwoNils(t *testing.T) {
 		t.Errorf("expect %v == %v; ", src, dst)
 	}
 
+}
+
+func TestImmutableTypes(t *testing.T) {
+	type Foo struct {
+		Time    time.Time
+		TimePtr *time.Time
+	}
+
+	now := time.Now()
+
+	src := &Foo{
+		Time:    time.Now(),
+		TimePtr: &now,
+	}
+
+	RegisterImmutableType(TypeOf(time.Time{}))
+
+	dst := MustAnything(src)
+
+	if src.TimePtr == dst.(*Foo).TimePtr {
+		t.Error("expect pointers to different time structs")
+	}
+
+	if !DeepEqual(src, dst) {
+		t.Errorf("expect %v == %v; ", src, dst)
+	}
 }


### PR DESCRIPTION
Adds `RegisterImmutableType(t Type)` that registers a type as immutable. This means that when a deep copy is made, if the type of the value being copied is the same as the type passed in, the value will not be copied. Instead, the original value will be used. This is useful for types that are immutable

Fixes: https://github.com/barkimedes/go-deepcopy/issues/6 assuming that the library user adds:
```
RegisterImmutableType(reflect.TypeOf(time.Time{}))
```
