### PR TITLE
Custom type copier registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ coverage.html
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.idea
+

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## Go Deep Copy
 
-[![Build Status](https://travis-ci.org/barkimedes/go-deepcopy.svg?branch=master)](https://travis-ci.org/barkimedes/go-deepcopy) [![codecov](https://codecov.io/gh/barkimedes/go-deepcopy/branch/master/graph/badge.svg)](https://codecov.io/gh/barkimedes/go-deepcopy) [![](https://godoc.org/github.com/nathany/looper?status.svg)](https://godoc.org/github.com/barkimedes/go-deepcopy)
-
-This package is a Golang implementation for creating deep copies of virtually any kind of Go type. 
+This package is a Golang implementation for creating deep copies of virtually any kind of Go type.
 
 This is a truly deep copy--every single value behind a pointer, every item in a slice or array, and every key and value in a map are all cloned so nothing is pointing to what it pointed to before.
 
 To handle circular pointer references (e.g. a pointer to a struct with a pointer field that points back to the original struct), we keep track of a map of pointers that have already been visited. This serves two purposes. First, it keeps us from getting into any kind of infinite loop. Second, it ensures that the code will behave similarly to how it would have on the original struct -- if you expect two values to be pointing at the same value within the copied tree, then they'll both still point to the same thing.
+
+This repo is a fork of [barkimedes/go-deepcopy](https://github.com/barkimedes/go-deepcopy). It doesn't seem to be maintained anymore, so I've forked it to make some changes and improvements. Major fix is on `time.Time` type, which is not handled properly in the original repo.
 
 ### Sample Program
 

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -145,6 +145,8 @@ func _pointer(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) 
 		if iv.IsValid() {
 			dc.Elem().Set(ValueOf(item))
 		}
+	} else {
+		return nil, nil
 	}
 	return dc.Interface(), nil
 }

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -129,6 +129,9 @@ func _pointer(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) 
 	if v.Kind() != Ptr {
 		return nil, fmt.Errorf("must pass a value with kind of Ptr; got %v", v.Kind())
 	}
+	if v.IsNil() {
+		return nil, nil
+	}
 	addr := v.Pointer()
 	if dc, ok := ptrs[addr]; ok {
 		return dc, nil
@@ -165,7 +168,9 @@ func _struct(x interface{}, ptrs map[uintptr]interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to copy the field %v in the struct %#v: %v", t.Field(i).Name, x, err)
 		}
-		dc.Elem().Field(i).Set(ValueOf(item))
+		if item != nil {
+			dc.Elem().Field(i).Set(ValueOf(item))
+		}
 	}
 	return dc.Elem().Interface(), nil
 }

--- a/deepcopy.go
+++ b/deepcopy.go
@@ -38,9 +38,12 @@ func init() {
 		Struct:     _struct,
 	}
 
-	typeCopiers = map[Type]copier{
-		TypeOf(time.Time{}): _time,
-	}
+	typeCopiers = map[Type]copier{}
+	RegisterTypeCopier(TypeOf(time.Time{}), _time)
+}
+
+func RegisterTypeCopier(t Type, c copier) {
+	typeCopiers[t] = c
 }
 
 // MustAnything does a deep copy and panics on any errors.

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	. "reflect"
 	"testing"
+	"time"
 )
 
 func ExampleAnything() {
@@ -160,7 +161,6 @@ func TestCopyNilValue(t *testing.T) {
 	type Foo struct {
 		Bar *Bar
 	}
-
 	s := &Foo{
 		Bar: nil,
 	}
@@ -171,5 +171,46 @@ func TestCopyNilValue(t *testing.T) {
 
 	if !DeepEqual(s, c) {
 		t.Fatalf("original and copied struct are not equal: %+v != %+v", s, c)
+	}
+}
+
+func TestTimeType(t *testing.T) {
+	src := time.Date(2016, 1, 1, 1, 0, 0, 0, time.UTC)
+	dst, err := Anything(src)
+	if err != nil {
+		t.Errorf("expected no error; got %v", err)
+	}
+	resultTime, ok := dst.(time.Time)
+	if !ok {
+		t.Errorf("expected a time.Time; got %v", resultTime)
+	}
+	if !DeepEqual(src, dst) {
+		t.Errorf("expect %v == %v; ", src, dst)
+	}
+
+}
+
+func TestTimePtrType(t *testing.T) {
+	type Foo struct {
+		T    time.Time
+		TPtr *time.Time
+	}
+
+	aTime := time.Date(2016, 1, 1, 1, 0, 0, 0, time.UTC)
+	anotherTime := aTime.Add(24 * time.Hour)
+	src := Foo{
+		T:    aTime,
+		TPtr: &anotherTime,
+	}
+	dst, err := Anything(src)
+	if err != nil {
+		t.Errorf("expected no error; got %v", err)
+	}
+	res, ok := dst.(Foo)
+	if !ok {
+		t.Errorf("expected a time.Time; got %v", res)
+	}
+	if !DeepEqual(src, dst) {
+		t.Errorf("expect %v == %v; ", src, dst)
 	}
 }

--- a/deepcopy_test.go
+++ b/deepcopy_test.go
@@ -57,10 +57,10 @@ func ExampleMap() {
 	}
 	// Output:
 	// x["foo"] = y["foo"]: false
-	// x["foo"].Foo = y["foo"].Foo: false
+	// x["foo"].Foo = y["foo"].Foo: true
 	// x["foo"].Bar = y["foo"].Bar: true
 	// x["bar"] = y["bar"]: false
-	// x["bar"].Foo = y["bar"].Foo: false
+	// x["bar"].Foo = y["bar"].Foo: true
 	// x["bar"].Bar = y["bar"].Bar: true
 }
 
@@ -150,5 +150,26 @@ func TestMismatchedTypesFail(t *testing.T) {
 				t.Errorf("%v attempted value %v as %v; should have gotten an error", test.kind, test.input, kind)
 			}
 		}
+	}
+}
+
+func TestCopyNilValue(t *testing.T) {
+	type Bar struct {
+		Baz string
+	}
+	type Foo struct {
+		Bar *Bar
+	}
+
+	s := &Foo{
+		Bar: nil,
+	}
+	c, err := Anything(s)
+	if err != nil {
+		t.Fatalf("deepcopy of struct %#v failed", s)
+	}
+
+	if !DeepEqual(s, c) {
+		t.Fatalf("original and copied struct are not equal: %+v != %+v", s, c)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/barkimedes/go-deepcopy
+
+go 1.22


### PR DESCRIPTION
Implements custom-type copier registration. Consumers are be able to register custom copiers if needed.